### PR TITLE
[Feature] Added some method to get data from legacy data type using offsets

### DIFF
--- a/src/api/nitro/room/object/data/type/LegacyDataType.ts
+++ b/src/api/nitro/room/object/data/type/LegacyDataType.ts
@@ -14,7 +14,6 @@ export class LegacyDataType extends ObjectDataBase implements IObjectData
     constructor()
     {
         super();
-
         this._data = '';
     }
 
@@ -45,6 +44,11 @@ export class LegacyDataType extends ObjectDataBase implements IObjectData
     public getLegacyString(): string
     {
         return this._data;
+    }
+
+    public getLegacyStringWithOffset(offset: number)
+    {
+        return this._data.split('\n')[offset];
     }
 
     public compare(data: IObjectData): boolean


### PR DESCRIPTION
The legacy data type store in stuffData is stored in the following format:

```
data1\n
data2\n
data3\n
```

What means that to obtain the data3, we should split the data using the separator '\n' and get the string using the offset in this array.

This will be necessary to some fix that I'll provide to nitro-react, that uses the stuffData to obtain the song disk name, and therefore the stuffData is in Legacy Data forrmat.

Some example:

![image](https://github.com/billsonnn/nitro-renderer/assets/24923784/2cb04542-9fb8-4a24-8974-38ead32f0d81)

In this case the we have the song name at the index 5 (considering 0)
