### PR TITLE
Fix camera effects not showing

### DIFF
--- a/packages/camera/src/RoomCameraWidgetManager.ts
+++ b/packages/camera/src/RoomCameraWidgetManager.ts
@@ -107,7 +107,7 @@ export class RoomCameraWidgetManager implements IRoomCameraWidgetManager
 
         container.filters = filters;
 
-        return await TextureUtils.generateImage(sprite);
+        return await TextureUtils.generateImage(container);
     }
 
     public get effects(): Map<string, IRoomCameraWidgetEffect>


### PR DESCRIPTION
`sprite` should be `container`, was probably a typo.