### PR TITLE
Fix direction in FurnitureChangeStateWhenStepOnLogic

### DIFF
--- a/packages/room/src/object/logic/furniture/FurnitureChangeStateWhenStepOnLogic.ts
+++ b/packages/room/src/object/logic/furniture/FurnitureChangeStateWhenStepOnLogic.ts
@@ -37,7 +37,7 @@ export class FurnitureChangeStateWhenStepOnLogic extends FurnitureLogic
         let sizeX = this.object.model.getValue<number>(RoomObjectVariable.FURNITURE_SIZE_X);
         let sizeY = this.object.model.getValue<number>(RoomObjectVariable.FURNITURE_SIZE_Y);
 
-        const direction = (((Math.floor(this.object.getDirection().x) + 45) % 360) / 90);
+        const direction = Math.floor(((this.object.getDirection().x + 45) % 360) / 90);
 
         if((direction === 1) || (direction === 3)) [sizeX, sizeY] = [sizeY, sizeX];
 


### PR DESCRIPTION
The direction was not changed because the return of the calculation was never an integer, so it could never reach the conditions that change the position of the furniture. This may not be the best way to fix this, but for all the furniture I've tested, it works perfectly.

Before
![GIF55](https://github.com/user-attachments/assets/6cf2c202-37ae-4b14-9317-5fe913a988ff)

After
![GIF56](https://github.com/user-attachments/assets/f8b22dcb-d4fc-40a8-8a01-1958e6f5c46c)
