### PR TITLE
New avatar clothing animation && empty parts figures

### DIFF
--- a/src/nitro/avatar/AvatarAssetDownloadManager.ts
+++ b/src/nitro/avatar/AvatarAssetDownloadManager.ts
@@ -106,7 +106,7 @@ export class AvatarAssetDownloadManager extends EventDispatcher
 
             downloadLibrary.addEventListener(AvatarRenderLibraryEvent.DOWNLOAD_COMPLETE, this.onLibraryLoaded);
 
-            for(const part of library.parts)
+            for(const part of (library.parts || []))
             {
                 const id = (part.id as string);
                 const type = (part.type as string);

--- a/src/nitro/avatar/cache/AvatarImageCache.ts
+++ b/src/nitro/avatar/cache/AvatarImageCache.ts
@@ -25,6 +25,7 @@ export class AvatarImageCache
     private _canvas: AvatarCanvas;
     private _disposed: boolean;
     private _geometryType: string;
+    private _defaultAction: string = 'std';
     private _unionImages: ImageData[];
     private _matrix: Matrix;
     private _serverRenderData: RoomObjectSpriteData[];
@@ -143,6 +144,7 @@ export class AvatarImageCache
         {
             this._geometryType = k;
             this._canvas = null;
+            this._defaultAction = (k === GeometryType.HORIZONTAL) ? 'lay' : 'std';
 
             return;
         }
@@ -151,6 +153,7 @@ export class AvatarImageCache
 
         this._geometryType = k;
         this._canvas = null;
+        this._defaultAction = (k === GeometryType.HORIZONTAL) ? 'lay' : 'std';
     }
 
     public getImageContainer(k: string, frameNumber: number, _arg_3: boolean = false): AvatarImageBodyPartContainer
@@ -376,9 +379,24 @@ export class AvatarImageCache
                     let assetName = (this._scale + '_' + assetPartDefinition + '_' + partType + '_' + partId + '_' + assetDirection + '_' + frameNumber);
                     let asset = this._assets.getAsset(assetName);
 
+                    // Fallback 1: frame 0 for action
                     if(!asset)
                     {
-                        assetName = (this._scale + '_std_' + partType + '_' + partId + '_' + assetDirection + '_0');
+                        assetName = (this._scale + '_' + assetPartDefinition + '_' + partType + '_' + partId + '_' + assetDirection + '_0');
+                        asset = this._assets.getAsset(assetName);
+                    }
+
+                    // Fallback 2: same frame from default action (std or lay)
+                    if(!asset)
+                    {
+                        assetName = (this._scale + '_' + this._defaultAction + '_' + partType + '_' + partId + '_' + assetDirection + '_' + frameNumber);
+                        asset = this._assets.getAsset(assetName);
+                    }
+
+                    // Fallback 3: default fram 0
+                    if(!asset)
+                    {
+                        assetName = (this._scale + '_' + this._defaultAction + '_' + partType + '_' + partId + '_' + assetDirection + '_0');
                         asset = this._assets.getAsset(assetName);
                     }
 

--- a/src/nitro/avatar/data/HabboAvatarAnimations.ts
+++ b/src/nitro/avatar/data/HabboAvatarAnimations.ts
@@ -1,6 +1,476 @@
 export const HabboAvatarAnimations = {
     'animations': [
         {
+            'id': 'Default',
+            'parts': [
+                {
+                    'setType': 'bd',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'bds',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'lg',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'sh',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'ch',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'cc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'lc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'rc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'lh',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'lhs',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'rh',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'rhs',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'ls',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'rs',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'he',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                },
+                {
+                    'setType': 'wa',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                }
+            ]
+        },
+        {
+            'id': 'Sit',
+            'parts': [
+                {
+                    'setType': 'bd',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'bds',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'lg',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'sh',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'ch',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'cc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'lc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'rc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'sit' },
+                        { 'number': 1, 'assetPartDefinition': 'sit' },
+                        { 'number': 2, 'assetPartDefinition': 'sit' },
+                        { 'number': 3, 'assetPartDefinition': 'sit' },
+                        { 'number': 4, 'assetPartDefinition': 'sit' },
+                        { 'number': 5, 'assetPartDefinition': 'sit' },
+                        { 'number': 6, 'assetPartDefinition': 'sit' },
+                        { 'number': 7, 'assetPartDefinition': 'sit' }
+                    ]
+                },
+                {
+                    'setType': 'wa',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'std' },
+                        { 'number': 1, 'assetPartDefinition': 'std' },
+                        { 'number': 2, 'assetPartDefinition': 'std' },
+                        { 'number': 3, 'assetPartDefinition': 'std' },
+                        { 'number': 4, 'assetPartDefinition': 'std' },
+                        { 'number': 5, 'assetPartDefinition': 'std' },
+                        { 'number': 6, 'assetPartDefinition': 'std' },
+                        { 'number': 7, 'assetPartDefinition': 'std' }
+                    ]
+                }
+            ]
+        },
+        {
+            'id': 'Lay',
+            'parts': [
+                {
+                    'setType': 'bd',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'bds',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'lg',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'sh',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'ch',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'cc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'lc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'rc',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'wa',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                },
+                {
+                    'setType': 'he',
+                    'frames': [
+                        { 'number': 0, 'assetPartDefinition': 'lay' },
+                        { 'number': 1, 'assetPartDefinition': 'lay' },
+                        { 'number': 2, 'assetPartDefinition': 'lay' },
+                        { 'number': 3, 'assetPartDefinition': 'lay' },
+                        { 'number': 4, 'assetPartDefinition': 'lay' },
+                        { 'number': 5, 'assetPartDefinition': 'lay' },
+                        { 'number': 6, 'assetPartDefinition': 'lay' },
+                        { 'number': 7, 'assetPartDefinition': 'lay' }
+                    ]
+                }
+            ]
+        },
+        {
             'id': 'Move',
             'parts': [
                 {


### PR DESCRIPTION
Added functionality to support animated clothing across every avatar action (walk, wave, sit, blablabla). 

Changes:
- Added HabboAvatarAnimations.ts with animation frame data for all actions
- Updated AvatarImageCache.ts with animation frame fallback logic

Fix: Handle figuremap libraries without parts property

Some figuremap.json entries don't have a parts array(especially some NFT-clotghes, causing "library.parts is not iterable" error. Added fallback to empty array to gracefully skip these entries.
